### PR TITLE
Select gamefield and show bookings

### DIFF
--- a/app/gamefields/page.tsx
+++ b/app/gamefields/page.tsx
@@ -1,12 +1,122 @@
 "use client";
-import React from "react";
+import Loader from "@/components/loader/Loader";
+import axios from "axios";
+import Link from "next/link";
+import React, { useEffect, useState } from "react";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
-function Gamefields() {
-  return (
-    <div>
-      <h1>Gamefields</h1>
-    </div>
-  );
+function Organizations() {
+  const [loading, setLoading] = useState(false);
+  const [gamefields, setGamefields] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      fetchGamefields();
+    }
+  }, []);
+
+  const fetchGamefields = async () => {
+    setLoading(true);
+    const API_URL = "https://callejero.com.co/test/api/v1";
+    const organizationId = localStorage.getItem("organizationId");
+    try {
+      const res = await axios
+        .get(`${API_URL}/game-fields/org/${organizationId}`, {
+          headers: {
+            "x-callejero-web-token": localStorage.getItem("auth"),
+            "x-tz": localStorage.getItem("timezone"),
+            "accept-language": "es",
+          },
+        })
+        .then((res) => {
+          const gamefieldsFound = res.data.data.results;
+          const firstGamefieldId = gamefieldsFound[0].id;
+          if (gamefieldsFound.length == 1) {
+            window.location.href = "/gamefields";
+          } else {
+            setGamefields(gamefieldsFound);
+          }
+          if (res.status == 200) {
+            toast.success("Canchas cargadas!", {
+              autoClose: 2000,
+              icon: "✅",
+            });
+            setLoading(false);
+          }
+        });
+    } catch (error) {
+      toast.error("Something failed!", {
+        autoClose: 2000,
+        icon: "❌",
+      });
+      setLoading(false);
+    }
+  };
+
+  const handleSelectGamefield = (id: string, name: string) => {
+    localStorage.setItem("gamefieldId", id);
+    localStorage.setItem("gamefieldName", name);
+    window.location.href = "/schedule";
+  };
+
+  //middleware
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const path = window.location.href;
+      if (!path.includes("/login")) {
+        validateToken();
+      }
+    }
+  }, []);
+  const validateToken = () => {
+    const token = localStorage.getItem("auth");
+    if (token) {
+      setVisible(true);
+    } else {
+      window.location.href = "/login";
+    }
+  };
+
+  if (visible)
+    return (
+      <div
+        className="text-center items-center flex h-screen"
+        style={{ height: "calc(100vh - 80px)" }}
+      >
+        <ToastContainer />
+        <div className="w-full">
+          {loading ? (
+            <>
+              <h1 className="text-4xl font-bold">Cargando Canchas</h1>
+              <Loader />
+            </>
+          ) : (
+            <>
+              <h1 className="text-6xl font-bold">
+                {localStorage.getItem("organizationName")}
+              </h1>
+              <h2 className="text-4xl font-bold mt-8">Selecciona una cancha</h2>
+              <div className="mx-auto sm:w-3/12 lg:w-2/12 w-5/12">
+                {gamefields.map((gamefield) => (
+                  <button
+                    onClick={() =>
+                      handleSelectGamefield(gamefield.id, gamefield.name)
+                    }
+                    key={gamefield.id}
+                    className="mt-8 bg-callejero px-4 py-4 block mx-auto font-semibold 
+                    rounded-full text-white hover:scale-105 transition-all w-44"
+                  >
+                    {gamefield.name}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    );
 }
 
-export default Gamefields;
+export default Organizations;

--- a/app/organizations/page.tsx
+++ b/app/organizations/page.tsx
@@ -32,15 +32,15 @@ function Organizations() {
         .then((res) => {
           const orgsFound = res.data.data;
           const firstGamefieldId = orgsFound[0].gameFields[0];
-          console.log("organizations", orgsFound);
-          console.log("first gamefield Id", firstGamefieldId);
-          if (organizations.length == 1) {
+          if (orgsFound.length == 1) {
+            localStorage.setItem("organizationId", orgsFound[0]._id);
+            localStorage.setItem("organizationName", orgsFound[0].name);
             window.location.href = "/gamefields";
           } else {
             setOrganizations(orgsFound);
           }
-          if (res.status == 200) {
-            toast.success("Organizations Found!", {
+          if (res.status == 200 && orgsFound.length > 1) {
+            toast.success("Organizaciones cargadas!", {
               autoClose: 2000,
               icon: "✅",
             });
@@ -67,7 +67,6 @@ function Organizations() {
   useEffect(() => {
     if (typeof window !== "undefined") {
       const path = window.location.href;
-      console.log("path", path);
       if (!path.includes("/login")) {
         validateToken();
       }
@@ -86,7 +85,7 @@ function Organizations() {
     return (
       <div
         className="text-center items-center flex h-screen"
-        style={{ height: "calc(100vh)" }}
+        style={{ height: "calc(100vh - 80px)" }}
       >
         <ToastContainer />
         <div className="w-full">

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -2,13 +2,58 @@
 import React, { useEffect, useState } from "react";
 import Calendar from "@/components/Calendar/Calendar";
 import Loader from "@/components/loader/Loader";
+import axios from "axios";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 function Schedule() {
   const [loading, setLoading] = useState(false);
+  const [bookings, setBookings] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      fetchBookings();
+    }
+  }, []);
+
+  const fetchBookings = async () => {
+    setLoading(true);
+    const API_URL = "https://callejero.com.co/test/api/v1";
+    const gameFieldId = localStorage.getItem("gamefieldId");
+    try {
+      const res = await axios
+        .get(
+          `${API_URL}/game-fields/${gameFieldId}/booking/get-all-bookings?date=2023-09-15`,
+          {
+            headers: {
+              "x-callejero-web-token": localStorage.getItem("auth"),
+              "x-tz": localStorage.getItem("timezone"),
+              "accept-language": "es",
+            },
+          }
+        )
+        .then((res) => {
+          const bookingsFound = res.data.data.schedules;
+          setBookings(bookingsFound);
+          if (res.status == 200) {
+            toast.success("Organizaciones cargadas!", {
+              autoClose: 2000,
+              icon: "✅",
+            });
+            setLoading(false);
+          }
+        });
+    } catch (error) {
+      toast.error("Something failed!", {
+        autoClose: 2000,
+        icon: "❌",
+      });
+      setLoading(false);
+    }
+  };
 
   //middleware
   const [visible, setVisible] = useState(false);
-
   useEffect(() => {
     if (typeof window !== "undefined") {
       const path = window.location.href;
@@ -18,7 +63,6 @@ function Schedule() {
       }
     }
   }, []);
-
   const validateToken = () => {
     const token = localStorage.getItem("auth");
     if (token) {
@@ -28,7 +72,25 @@ function Schedule() {
     }
   };
 
-  if (visible) return <div>{loading ? <Loader /> : <Calendar />}</div>;
+  if (visible)
+    return (
+      <div
+        className="text-center items-center flex h-screen"
+        style={{ height: "calc(100vh - 80px)" }}
+      >
+        <ToastContainer />
+        <div className="w-full">
+          {loading ? (
+            <>
+              <h1 className="text-4xl font-bold">Cargando Reservas</h1>
+              <Loader />
+            </>
+          ) : (
+            <Calendar data={bookings} />
+          )}
+        </div>
+      </div>
+    );
 }
 
 export default Schedule;

--- a/components/Calendar/Calendar.tsx
+++ b/components/Calendar/Calendar.tsx
@@ -6,11 +6,17 @@ import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
 
 import "./Calendar.css";
+import { useState } from "react";
 
-function Calendar() {
+function Calendar(data: any) {
+  const [bookings, setBookings] = useState(data.data);
   return (
     <div className="calendar bg-callejero">
       <div className="calendar__grid bg-white p-6">
+        <h1 className="text-2xl mb-6">
+          {localStorage.getItem("organizationName")} /{" "}
+          <b>{localStorage.getItem("gamefieldName")}</b>
+        </h1>
         <Fullcalendar
           locale={esLocale}
           plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
@@ -21,17 +27,12 @@ function Calendar() {
             end: "dayGridMonth,timeGridWeek,timeGridDay", // will normally be on the right. if RTL, will be on the left
           }}
           height={"90vh"}
-          // events={["2023-09-04"]}
           eventColor={"#184135"}
-          events={[
-            { title: "Juego de Practica", date: "2023-09-04T08:00:00" },
-            {
-              title: "Reserva Juan",
-              start: "2023-09-07T12:00:00",
-              end: "2023-09-07T12:30:00",
-            },
-            { title: "Reservado", date: "2023-09-05" },
-          ]}
+          events={bookings.map((booking: any) => ({
+            title: "Reserva",
+            start: booking.startsAt,
+            end: booking.endsAt,
+          }))}
         />
       </div>
     </div>


### PR DESCRIPTION
📢 Type of change
[ ] Bugfix
[x] New feature
[ ] Enhancement
[ ] Refactoring
[ ] Release

📜 Motivation and Context
We need the "Select Gamefield View" to regist which specific gamefield we are goint to charge on the calendar and show these bookings on it.

🎨 UI changes

Select Gamefield View ->

<img src="https://github.com/callejero-app/callejero-front/assets/32417973/e2d049cf-ee64-4c1e-afea-e62704bd6ebc" width="700">&emsp;

Calendar month View ->

<img src="https://github.com/callejero-app/callejero-front/assets/32417973/32a4b6da-0f80-4142-b1c2-856050c3a28f" width="700">&emsp;

Calendar week View -> 

<img src="https://github.com/callejero-app/callejero-front/assets/32417973/98406c62-2b3b-4ad4-b387-b807452f033c" width="700">&emsp;

💚 How did you test it?
1. Log in
2. Select an organization in case that the client have more than one
3. Select a gamefield
4. the calendar should charge the booking of the gamefield selected and show the names of the organization and the gamefield selected on the top of the calendar.

📌 Related ticket(s)
https://callejero.atlassian.net/browse/JERO-264