### PR TITLE
Today and event styles

### DIFF
--- a/app/gamefields/page.tsx
+++ b/app/gamefields/page.tsx
@@ -40,7 +40,6 @@ function Organizations() {
           const gamefieldsTuplesJSON = JSON.stringify(gamefieldsTuples);
           localStorage.setItem("gamefieldsTuples", gamefieldsTuplesJSON);
           const storage = localStorage.getItem("gamefieldsTuples");
-          console.log("storage", storage);
           if (gamefieldsFound.length == 1) {
             window.location.href = "/gamefields";
           } else {

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -27,6 +27,7 @@ function Schedule() {
       fetchBookings(localStorage.getItem("gamefieldId")!);
     }
   }, []);
+
   useEffect(() => {
     if (typeof window !== "undefined") {
       if (!gridModified) insertPrevButtonInCalendar();
@@ -34,6 +35,7 @@ function Schedule() {
       setVisible(true);
     }
   }, []);
+
   const insertPrevButtonInCalendar = () => {
     const timer = setTimeout(() => {
       //prev next button
@@ -66,7 +68,7 @@ function Schedule() {
         .get(url, {
           params: {
             "start-date": "2023-08-01",
-            "end-date": "2023-10-30",
+            "end-date": "2023-12-30",
           },
           headers: {
             "x-callejero-web-token": localStorage.getItem("auth"),

--- a/components/Calendar/Calendar.scss
+++ b/components/Calendar/Calendar.scss
@@ -146,5 +146,45 @@ td.fc-timegrid-slot.fc-timegrid-slot-label.fc-scrollgrid-shrink.slotTimes {
 
 th.fc-col-header-cell.fc-day {
   height: 48px;
-  padding: 16px;
+  padding: 8px 16px;
+}
+
+// weekdays
+.fc .fc-col-header-cell-cushion {
+  padding: 8px;
+}
+
+// weekday today box
+th.fc-col-header-cell.fc-day.fc-day-today.dayHeader {
+  background: #e0e9e6;
+  & a {
+    background: #557b6b;
+    border-radius: 8px;
+    // padding: 8px;
+    & .headerDay,
+    .headerWeekday {
+      color: white;
+    }
+  }
+}
+
+//cell today background
+.fc .fc-timegrid-col.fc-day-today {
+  background: white;
+}
+
+//events styles
+.own-event {
+  padding: 10px;
+  margin: 8px;
+  border-radius: 8px;
+}
+
+.fc-v-event .fc-event-main-frame {
+  flex-flow: wrap-reverse;
+  align-content: start;
+}
+
+.fc-v-event .fc-event-title {
+  font-weight: 500;
 }

--- a/components/Calendar/Calendar.tsx
+++ b/components/Calendar/Calendar.tsx
@@ -83,6 +83,7 @@ function Calendar(data: any) {
                   }))
                 : {}
             }
+            eventClassNames={"own-event"}
           />
         </div>
       </div>


### PR DESCRIPTION
📢 Type of change
[ ] Bugfix
[x] New feature
[ ] Enhancement
[ ] Refactoring
[ ] Release

📜 Motivation and Context
In this PR we apply style to Today cell in Full Calendar and Events to reach our figma design porpuse.

🎨 UI changes
View 1

<img width="1470" src="https://github.com/callejero-app/callejero-front/assets/32417973/e969ab34-6959-42c5-96b6-c45fff2f94a4">


💚 How did you test it?
1. In schedule section we should see the new styles of events and today cell

📌 Related ticket(s)
https://callejero.atlassian.net/browse/JERO-332