### PR TITLE
Delete APP bookings and partial booking color change to yellow

### DIFF
--- a/components/Calendar/Calendar.scss
+++ b/components/Calendar/Calendar.scss
@@ -200,6 +200,11 @@ th.fc-col-header-cell.fc-day.fc-day-today.dayHeader {
     border: 1px solid #576763 !important;
     border-radius: 8px;
   }
+  &__partial {
+    background-color: #ffc12f !important;
+    border: 1px solid #ffc12f !important;
+    border-radius: 8px;
+  }
 }
 
 .fc-v-event .fc-event-main-frame {

--- a/components/Calendar/Calendar.tsx
+++ b/components/Calendar/Calendar.tsx
@@ -99,6 +99,7 @@ const Calendar: FC<{
       description:
         booking.description != null ? booking.description : "Sin descripcción",
       isHistory: booking.isHistory,
+      className: booking.status === "partial" && "own-event__partial",
     }));
     //history
     const historyEvents = historyReceiveds.map((historyEl: any) => ({
@@ -444,7 +445,6 @@ const Calendar: FC<{
                   });
                 }
                 if (!justCreated && !sub) {
-                  console.log("history entra aqui", e);
                   const tag = e.event._def.extendedProps.detail.originPlatform;
                   const isHistory = e.event._def.extendedProps.detail.isHistory;
                   const start = new Date(
@@ -473,8 +473,10 @@ const Calendar: FC<{
                     id: t.teamLeader.id,
                   }));
                   const id = e.event._def.extendedProps.detail.id;
+                  const status = e.event._def.extendedProps.detail.status;
                   setBookingDetail({
                     id: id,
+                    status: status,
                     tag: tag,
                     isHistory: isHistory,
                     paymentCompleted: paymentCompleted,

--- a/components/ModalEventDetail/index.tsx
+++ b/components/ModalEventDetail/index.tsx
@@ -39,6 +39,7 @@ const ModalEventDetail: React.FC<{
     responsables: [];
     totalPrice: number;
     totalPaid: number;
+    status: string;
   };
   openEventDetail: boolean;
   updateOpenEventDetail: Function;
@@ -84,6 +85,7 @@ const ModalEventDetail: React.FC<{
     responsables: bookingDetail.responsables,
     totalPrice: bookingDetail.totalPrice,
     totalPaid: bookingDetail.totalPaid,
+    status: bookingDetail.status,
   });
 
   const deleteBooking = async () => {
@@ -447,25 +449,27 @@ const ModalEventDetail: React.FC<{
                           Total: ${bookingReceived.totalPrice.toLocaleString()}
                         </p>
                       </div>
-                      <button
-                        className={`text-sm md:text-sm h-10 border bg-callejero text-white rounded-full px-6 
+                      {bookingReceived.tag !== "app" && (
+                        <button
+                          className={`text-sm md:text-sm h-10 border bg-callejero text-white rounded-full px-6 
                         w-[158px] transition-all ${
                           bookingClosed || paymentCompleted == true
                             ? "opacity-70 cursor-not-allowed hover:scale-100"
                             : "hover:scale-105"
                         }`}
-                        onClick={completePayment}
-                      >
-                        {loadingPayment ? (
-                          <Spinner size="sm" color="white" />
-                        ) : (
-                          `${
-                            bookingClosed || paymentCompleted
-                              ? "Pagado"
-                              : "Completar pago"
-                          } `
-                        )}
-                      </button>
+                          onClick={completePayment}
+                        >
+                          {loadingPayment ? (
+                            <Spinner size="sm" color="white" />
+                          ) : (
+                            `${
+                              bookingClosed || paymentCompleted
+                                ? "Pagado"
+                                : "Completar pago"
+                            } `
+                          )}
+                        </button>
+                      )}
                     </div>
                   </div>
                 )}
@@ -474,7 +478,8 @@ const ModalEventDetail: React.FC<{
                 )}
               </ModalBody>
               <ModalFooter>
-                {bookingReceived.tag === "web" ? (
+                {bookingReceived.tag === "web" ||
+                bookingReceived.status === "partial" ? (
                   <div className="flex w-full justify-between">
                     <button
                       className="h-12 w-40 border bg-red-600 rounded-full text-white text-base font-medium mb-2 


### PR DESCRIPTION
📢 Type of change
[ ] Bugfix
[x] New feature
[x] Enhancement
[ ] Refactoring
[ ] Release

📜 Motivation and Context
We need to be able to delete bookings that were created from the app, to reach this we did this:
1. Delete booking button in app bookings added.
2. Change color for partial bookings.
3. Hide complete payment button for app's booking.

🎨 UI changes

<img src="https://github.com/callejero-app/callejero-front/assets/32417973/2400865b-f348-49d4-9c25-9e0f4786cf6c" width="700">&emsp;
<img src="https://github.com/callejero-app/callejero-front/assets/32417973/ff307faf-508c-43ce-89ba-823324900093" width="700">&emsp;


💚 How did you test it?
1. We should see the delete button in bookings from APP
2. We should see a yellow events bookings on calendar that represents PARTIAL bookings from the app.
3. In every app booking partial or not, we DON'T have to see the complete payment button.

📌 Related ticket(s)
https://callejero.atlassian.net/browse/JERO-558